### PR TITLE
Bug fix for 'plain text' messages. Passing the 'parse_mode' item at a…

### DIFF
--- a/Serilog.Sinks.Telegram/Client/ITelegramClient.cs
+++ b/Serilog.Sinks.Telegram/Client/ITelegramClient.cs
@@ -1,0 +1,10 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.Telegram
+{
+    public interface ITelegramClient
+    {
+        Task<HttpResponseMessage> PostAsync(TelegramMessage message, string chatId);
+    }
+}

--- a/Serilog.Sinks.Telegram/Client/ITelegramClientFactory.cs
+++ b/Serilog.Sinks.Telegram/Client/ITelegramClientFactory.cs
@@ -1,0 +1,10 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.Telegram
+{
+    public interface ITelegramClientFactory
+    {
+        ITelegramClient CreateClient(string botToken, int timeoutSeconds = 10);
+    }
+}

--- a/Serilog.Sinks.Telegram/Client/TelegramClient.cs
+++ b/Serilog.Sinks.Telegram/Client/TelegramClient.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Serilog.Sinks.Telegram
 {
-    public class TelegramClient
+    public class TelegramClient : ITelegramClient
     {
         private readonly Uri _apiUrl;
         private readonly HttpClient _httpClient = new HttpClient();
@@ -26,7 +27,8 @@ namespace Serilog.Sinks.Telegram
 
             // If the message type is 'Plain', the 'parse_mode' key CANNOT be present at all,
             // else the Telegram API will attempt to parse the message string as a MarkDown.
-            if (message.ParseMode == Client.TelegramParseModeTypes.Plain)
+            if (message.ParseMode == Client.TelegramParseModeTypes.Plain ||
+                !ValidateMessage(message))
             {
                 var payload = new
                 {
@@ -46,10 +48,72 @@ namespace Serilog.Sinks.Telegram
                 json = JsonConvert.SerializeObject(value: payload);
             }
 
-            var response = await _httpClient.PostAsync(requestUri: _apiUrl,
-                content: new StringContent(content: json, encoding: Encoding.UTF8, mediaType: "application/json"));
+            var response = await _httpClient.PostAsync(
+                requestUri: _apiUrl,
+                content: new StringContent(
+                    content: json, encoding: Encoding.UTF8, mediaType: "application/json"));
 
             return response;
+        }
+
+        /// <summary>
+        /// These methods should be extended to validate all the cases where Telegram
+        /// will reject a 'Markdown' or 'Html' formatted string as 'BadRequest'.
+        /// </summary>
+        /// <example>
+        /// Message "*This is rejected" is rejected by Telegram as an invalid
+        /// markdown because it has an odd number of asterisks, instead of being ignored 
+        /// as it really should.
+        /// </example>
+        /// <param name="message"></param>
+        /// <returns>
+        /// True: message is valid for the parse mode type. 
+        /// False: invalid and should probably be handled as normal text.
+        /// </returns>
+        private bool ValidateMessage(TelegramMessage message)
+        {
+            switch (message.ParseMode)
+            {
+                case Client.TelegramParseModeTypes.Html:
+                    return ValidateMessageHtml(message);
+                case Client.TelegramParseModeTypes.Markdown:
+                    return ValidateMessageMarkdown(message);
+                case Client.TelegramParseModeTypes.Plain:
+                    break;
+            }
+
+            return true;    // Is valid
+        }
+
+        private bool ValidateMessageMarkdown(TelegramMessage message)
+        {
+            // Validate: *even is ok* and reject odd numbers of '*'
+            if (!Regex.IsMatch(message.Text, @"^[^*]*(\*[^*]*\*[^*]*)*$")) return false;
+            // Validate: _even is ok_ and reject odd numbers of '_'
+            if (!Regex.IsMatch(message.Text, @"^[^_]*(_[^_]*_[^_]*)*$")) return false;
+
+            // Validate: [inline URL](url)
+            // Validate: [inline mention of a user](tg://user?id=123456789)
+
+            // Validate: `inline fixed-width code`
+            if (!Regex.IsMatch(message.Text, @"^[^(`)]*(`[^(`)]*`[^(`)]*)*$")) return false;
+
+            // Validate:
+            //      ```block_language
+            //      pre - formatted fixed-width code block
+            //      ```
+            if (!Regex.IsMatch(message.Text, @"^[^(```)]*(```[^(```)]*```[^(```)]*)*$")) return false;
+
+            return true;    // Assume valid if we passed all tests above.
+        }
+
+        private bool ValidateMessageHtml(TelegramMessage message)
+        {
+            // Validate the cases where Telegram returns 'BadRequest'. These cases
+            // really need to be tested with real data because it's unclear what will
+            // trigger an error from Telegram.
+
+            return true;    // Assume everything is valid for now.
         }
     }
 }

--- a/Serilog.Sinks.Telegram/Client/TelegramClient.cs
+++ b/Serilog.Sinks.Telegram/Client/TelegramClient.cs
@@ -22,14 +22,30 @@ namespace Serilog.Sinks.Telegram
 
         public async Task<HttpResponseMessage> PostAsync(TelegramMessage message, string chatId)
         {
-            var payload = new
-            {
-                chat_id = chatId,
-                text = message.Text,
-                parse_mode = message.ParseMode.ToString().ToLower()
-            };
+            string json;
 
-            var json = JsonConvert.SerializeObject(value: payload);
+            // If the message type is 'Plain', the 'parse_mode' key CANNOT be present at all,
+            // else the Telegram API will attempt to parse the message string as a MarkDown.
+            if (message.ParseMode == Client.TelegramParseModeTypes.Plain)
+            {
+                var payload = new
+                {
+                    chat_id = chatId,
+                    text = message.Text
+                };
+                json = JsonConvert.SerializeObject(value: payload);
+            }
+            else
+            {
+                var payload = new
+                {
+                    chat_id = chatId,
+                    text = message.Text,
+                    parse_mode = message.ParseMode.ToString().ToLower()
+                };
+                json = JsonConvert.SerializeObject(value: payload);
+            }
+
             var response = await _httpClient.PostAsync(requestUri: _apiUrl,
                 content: new StringContent(content: json, encoding: Encoding.UTF8, mediaType: "application/json"));
 

--- a/Serilog.Sinks.Telegram/Client/TelegramClientFactory.cs
+++ b/Serilog.Sinks.Telegram/Client/TelegramClientFactory.cs
@@ -1,0 +1,13 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.Telegram
+{
+    public class TelegramClientFactory : ITelegramClientFactory
+    {
+        public ITelegramClient CreateClient(string botToken, int timeoutSeconds = 10)
+        {
+            return new TelegramClient(botToken, timeoutSeconds);
+        }
+    }
+}

--- a/Serilog.Sinks.Telegram/TelegramSinkExtension.cs
+++ b/Serilog.Sinks.Telegram/TelegramSinkExtension.cs
@@ -12,7 +12,8 @@ namespace Serilog.Sinks.Telegram
             string chatId,
             TelegramSink.RenderMessageMethod renderMessageImplementation = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            IFormatProvider formatProvider = null
+            IFormatProvider formatProvider = null,
+            ITelegramClientFactory telegramClientFactory = null
         )
         {
             if (loggerConfiguration == null)
@@ -23,7 +24,8 @@ namespace Serilog.Sinks.Telegram
                     chatId: chatId,
                     token: token,
                     renderMessageImplementation: renderMessageImplementation,
-                    formatProvider: formatProvider
+                    formatProvider: formatProvider,
+                    telegramClientFactory: telegramClientFactory
                 ),
                 restrictedToMinimumLevel: restrictedToMinimumLevel);
         }


### PR DESCRIPTION
Bug fix for 'plain text' messages. Passing the 'parse_mode' item at all makes Telegram attempt to interpret the message as 'MarkDown' even if type passed is 'Plain'. This will cause a message such as "*Fatal OMG!!!" to fail with "BadRequest".

As is, changing the message type to be used by the Telegram sink is very cumbersome, but that's another story.